### PR TITLE
"Feat : 상점 닉네임과 유저 닉네임 분리"

### DIFF
--- a/src/main/java/com/example/demo/kakao/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/example/demo/kakao/dto/KakaoUserInfoDto.java
@@ -8,12 +8,15 @@ import lombok.RequiredArgsConstructor;
 public class KakaoUserInfoDto {
     private final Long id;
     private final String nickname;
+    private final String email;
 
     public static KakaoUserInfoDto fromJson(JsonNode json) {
         Long id = json.get("id")
                 .asLong();
         String nickname = json.get("properties").get("nickname")
                 .asText();
-        return new KakaoUserInfoDto(id, nickname);
+        String email = json.get("kakao_account").get("email")
+                .asText();
+        return new KakaoUserInfoDto(id, nickname, email);
     }
 }

--- a/src/main/java/com/example/demo/kakao/service/KakaoService.java
+++ b/src/main/java/com/example/demo/kakao/service/KakaoService.java
@@ -107,11 +107,17 @@ public class KakaoService {
 
         boolean first = kakaoUser == null;
         if (first) {
-            String nickname = kakaoUserInfo.getNickname();
+            String nickname = kakaoUserInfo.getEmail();
+            nickname = getNicknameFromEmail(nickname);
             kakaoUser = new Member(kakaoId, nickname);
             memberRepository.save(kakaoUser);
         }
         return new Tray(kakaoUser, first);
+    }
+
+    private String getNicknameFromEmail(String email) {
+        String[] pieceOfEmail = email.split("@");
+        return pieceOfEmail[0];
     }
 
     record Tray(

--- a/src/main/java/com/example/demo/member/dto/MemberInfoRequestDto.java
+++ b/src/main/java/com/example/demo/member/dto/MemberInfoRequestDto.java
@@ -16,4 +16,8 @@ public class MemberInfoRequestDto {
     @JsonProperty(ParameterNameConfig.Member.NICKNAME)
     private String nickname;
 
+    @Schema(description = "유저 상점 닉네임", example = "고기닭고기 상점")
+    @JsonProperty(ParameterNameConfig.Shop.NAME)
+    private String shopName;
+
 }

--- a/src/main/java/com/example/demo/member/entity/Member.java
+++ b/src/main/java/com/example/demo/member/entity/Member.java
@@ -35,7 +35,7 @@ public class Member {
     @Column(name = "image", nullable = true)
     private URL image;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.PERSIST)
+    @OneToOne(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private Shop shop;
 
     @OneToMany(mappedBy = "member")

--- a/src/main/java/com/example/demo/member/service/MemberService.java
+++ b/src/main/java/com/example/demo/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.example.demo.location.entity.MemberLocation;
 import com.example.demo.member.dto.*;
 import com.example.demo.member.entity.Member;
 import com.example.demo.member.repository.MemberRepository;
+import com.example.demo.shop.entity.Shop;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -37,6 +38,9 @@ public class MemberService {
         // 닉네임 변경.
         changeNickname(memberLoggedIn, request.getNickname());
 
+        // 상점명 변경.
+        changeShopName(memberLoggedIn, request.getShopName());
+
         // 변경된 내용 저장.
         memberRepository.save(memberLoggedIn);
 
@@ -49,6 +53,13 @@ public class MemberService {
 
         validateUniqueNickname(nickname);
         member.setNickname(nickname);
+    }
+
+    private void changeShopName(Member member, String shopName) {
+        if(!StringUtils.hasText(shopName)) return;
+
+        Shop shop = member.getShop();
+        shop.setShopName(shopName);
     }
 
     private void validateUniqueNickname(String nickname) {

--- a/src/main/java/com/example/demo/shop/entity/Shop.java
+++ b/src/main/java/com/example/demo/shop/entity/Shop.java
@@ -23,7 +23,7 @@ public class Shop {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     private String shopName;
     @Column(name = "intro")
     private String shopIntro;


### PR DESCRIPTION
닉네임 변경 시 유저 닉네임과 상점 닉네임을 분리하도록 API 수정
소셜 로그인 시 닉네임을 이메일 앞 부분으로 설정